### PR TITLE
Fix docker-compose volume mount typo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
     ports:
       - 6379:6379
     volumes:
-      - ./redis_streamer/redis/redis_6789.conf:/usr/local/etc/redis/redis.conf
+      - ./redis-streamer/redis/redis_6789.conf:/usr/local/etc/redis/redis.conf
     environment:
       ALLOW_EMPTY_PASSWORD: 'yes'
     healthcheck:


### PR DESCRIPTION
Assuming the use of an underscore in the `redis-streamer` mount was a typo as new root-owned directories are being created for what seems to be a file path.